### PR TITLE
add nix flake support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: "Test"
+on:
+  pull_request: [ master ]
+  push: [ master ]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - run: nix flake show
+    - run: nix flake check
+    - run: nix build --print-build-logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .ham.d
 ham.pl
 ham.par
+**/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1638447404,
+        "narHash": "sha256-nSQR0ZsRwkEDGqqKTIQfs+b9lIQHi6EMW6gwk/EWdmQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d24027a6846d64d081f5a1c74aa02c49bf44d288",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        lib = pkgs.lib;
+      in
+      rec {
+        packages.ham = pkgs.stdenv.mkDerivation rec {
+          src = ./.;
+          name = "ham";
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          buildPhase = ''
+            runHook preInstall
+            
+            runHook postInstall
+          '';
+          installPhase = ''
+            runHook preInstall
+            
+            mkdir --parents $out/{bin,opt/${name}}
+            cp --recursive Hammer ham $out/opt/${name}
+            ln --relative --symbolic $out/opt/${name}/${name} $out/bin
+
+            runHook postInstall
+          '';
+          postFixup = ''
+            wrapProgram $out/opt/${name}/${name} \
+              --prefix PERL5LIB : "${with pkgs.perlPackages; makePerlPath [
+                BHooksEndOfScope
+                GitRepository
+                GitVersionCompare
+                ModuleImplementation
+                ModuleRuntime
+                PackageStash
+                SubExporterProgressive
+                SystemCommand
+                TryTiny
+                URI
+                XMLMini
+                namespaceclean
+              ]}"
+          '';
+        };
+        defaultPackage = packages.ham;
+        apps.ham = flake-utils.lib.mkApp { drv = packages.ham; };
+        defaultApp = apps.ham;
+      }
+    );
+}


### PR DESCRIPTION
Hi, I'd like to enable a seamless development experience for L4RE on nix based systems. As ham is a key component in the L4RE ecosystem, I started here. Basically, once this PR is merged anyone who happens to already have `nix` with flakes support installed can simply run `nix run github:kernkonzept/ham` and `ham` is automatically installed and already executed. So now, before the PR is merged, I can run  `nix run github:wucke13/ham` and I'm already presented with the help message of `ham`.

@Steav005 please check this one out and look if you see any issues.

In case this wasn't obvious, I'm one of the DLR folks who intend to take L4RE to the next level :smile: 