### PR TITLE
Fix use of undefined value in ham info

### DIFF
--- a/ham
+++ b/ham
@@ -1326,6 +1326,7 @@ sub cmd_info
     print colored("$p->{name}: in $p->{path}\n", 'bold');
     my $remote_branch = $p->{revision};
     $remote_branch = "<unknown branch>" unless defined $remote_branch;
+    $head = "<unknown>" unless defined $head;
     print "  remote: $p->{remote} @ branch ".colored($remote_branch, 'yellow')."\n";
     print "  local revision: ".colored($head, 'yellow')."\n";
     my $s = $p->status;


### PR DESCRIPTION
Fix error messages during ham info in cases where a repository had no local branch checked out.